### PR TITLE
API のエラーハンドリング

### DIFF
--- a/lib/features/weather/components/error_dialog.dart
+++ b/lib/features/weather/components/error_dialog.dart
@@ -10,9 +10,9 @@ class ErrorDialogWidget extends StatelessWidget {
     return AlertDialog(
       content: Text(_errorMessage),
       actions: [
-        GestureDetector(
+        TextButton(
           child: const Text('OK'),
-          onTap: () => Navigator.pop(context),
+          onPressed: () => Navigator.pop(context),
         ),
       ],
     );

--- a/lib/features/weather/components/error_dialog.dart
+++ b/lib/features/weather/components/error_dialog.dart
@@ -1,0 +1,20 @@
+import 'package:flutter/material.dart';
+
+class ErrorDialogWidget extends StatelessWidget {
+  const ErrorDialogWidget({required String errorMessage, super.key})
+      : _errorMessage = errorMessage;
+  final String _errorMessage;
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      content: Text(_errorMessage),
+      actions: [
+        GestureDetector(
+          child: const Text('OK'),
+          onTap: () => Navigator.pop(context),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/features/weather/exceptions/app_exception.dart
+++ b/lib/features/weather/exceptions/app_exception.dart
@@ -1,0 +1,18 @@
+import 'package:yumemi_weather/yumemi_weather.dart';
+
+class WeatherConditionException implements Exception {
+  const WeatherConditionException();
+  @override
+  String toString() {
+    return '不正なAPIレスポンスが返されました';
+  }
+}
+
+extension YumemiWeatherErrorExt on YumemiWeatherError {
+  String convertErrorMessage() {
+    return switch (this) {
+      YumemiWeatherError.unknown => 'APIのエラーが発生しました。',
+      YumemiWeatherError.invalidParameter => '不正な値が入力されました。'
+    };
+  }
+}

--- a/lib/features/weather/model/weather_condition.dart
+++ b/lib/features/weather/model/weather_condition.dart
@@ -1,3 +1,5 @@
+import 'package:flutter_training/features/weather/exceptions/app_exception.dart';
+
 enum WeatherCondition {
   sunny(image: 'assets/sunny.svg'),
   cloudy(image: 'assets/cloudy.svg'),
@@ -9,7 +11,7 @@ enum WeatherCondition {
   factory WeatherCondition.from(String name) =>
       WeatherCondition.values.singleWhere(
         (element) => element.name == name,
-        orElse: () => throw Exception('`$name` is invalid value'),
+        orElse: () => throw const WeatherConditionException(),
       );
 
   final String image;

--- a/lib/features/weather/screen/weather_screen.dart
+++ b/lib/features/weather/screen/weather_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_training/features/weather/components/error_dialog.dart';
 import 'package:flutter_training/features/weather/components/weather.dart';
+import 'package:flutter_training/features/weather/exceptions/app_exception.dart';
 import 'package:flutter_training/features/weather/model/weather_condition.dart';
 import 'package:yumemi_weather/yumemi_weather.dart';
 
@@ -9,15 +10,6 @@ class WeatherScreen extends StatefulWidget {
 
   @override
   State<WeatherScreen> createState() => _WeatherScreenState();
-}
-
-extension YumemiWeatherErrorExt on YumemiWeatherError {
-  String convertErrorMessage() {
-    return switch (this) {
-      YumemiWeatherError.unknown => 'APIのエラーが発生しました。',
-      YumemiWeatherError.invalidParameter => '不正な値が入力されました。'
-    };
-  }
 }
 
 class _WeatherScreenState extends State<WeatherScreen> {
@@ -39,6 +31,14 @@ class _WeatherScreenState extends State<WeatherScreen> {
         barrierDismissible: false,
         builder: (_) {
           return ErrorDialogWidget(errorMessage: e.convertErrorMessage());
+        },
+      );
+    } on WeatherConditionException catch (e) {
+      await showDialog<void>(
+        context: context,
+        barrierDismissible: false,
+        builder: (_) {
+          return ErrorDialogWidget(errorMessage: e.toString());
         },
       );
     }

--- a/lib/features/weather/screen/weather_screen.dart
+++ b/lib/features/weather/screen/weather_screen.dart
@@ -28,26 +28,22 @@ class _WeatherScreenState extends State<WeatherScreen> {
         _weather = weather;
       });
     } on YumemiWeatherError catch (e) {
-      unawaited(
-        showDialog<void>(
-          context: context,
-          barrierDismissible: false,
-          builder: (_) {
-            return ErrorDialogWidget(errorMessage: e.convertErrorMessage());
-          },
-        ),
-      );
+      _showErrorDialog(e.convertErrorMessage());
     } on WeatherConditionException catch (e) {
-      unawaited(
-        showDialog<void>(
-          context: context,
-          barrierDismissible: false,
-          builder: (_) {
-            return ErrorDialogWidget(errorMessage: e.toString());
-          },
-        ),
-      );
+      _showErrorDialog(e.toString());
     }
+  }
+
+  void _showErrorDialog(String message) {
+    unawaited(
+      showDialog<void>(
+        context: context,
+        barrierDismissible: false,
+        builder: (_) {
+          return ErrorDialogWidget(errorMessage: message);
+        },
+      ),
+    );
   }
 
   @override

--- a/lib/features/weather/screen/weather_screen.dart
+++ b/lib/features/weather/screen/weather_screen.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_training/features/weather/components/error_dialog.dart';
 import 'package:flutter_training/features/weather/components/weather.dart';
@@ -26,20 +28,24 @@ class _WeatherScreenState extends State<WeatherScreen> {
         _weather = weather;
       });
     } on YumemiWeatherError catch (e) {
-      await showDialog<void>(
-        context: context,
-        barrierDismissible: false,
-        builder: (_) {
-          return ErrorDialogWidget(errorMessage: e.convertErrorMessage());
-        },
+      unawaited(
+        showDialog<void>(
+          context: context,
+          barrierDismissible: false,
+          builder: (_) {
+            return ErrorDialogWidget(errorMessage: e.convertErrorMessage());
+          },
+        ),
       );
     } on WeatherConditionException catch (e) {
-      await showDialog<void>(
-        context: context,
-        barrierDismissible: false,
-        builder: (_) {
-          return ErrorDialogWidget(errorMessage: e.toString());
-        },
+      unawaited(
+        showDialog<void>(
+          context: context,
+          barrierDismissible: false,
+          builder: (_) {
+            return ErrorDialogWidget(errorMessage: e.toString());
+          },
+        ),
       );
     }
   }


### PR DESCRIPTION
## 課題

close #6 

## 対応箇所


- [x] 使用する API を fetchSimpleWeather() から fetchThrowsWeather() に変更する
- [x] API のエラーを補足して、エラーの内容に応じて [AlertDialog](https://api.flutter.dev/flutter/material/AlertDialog-class.html) でメッセージを表示する
- [x] [AlertDialog](https://api.flutter.dev/flutter/material/AlertDialog-class.html) の OK ボタンをタップすると、ダイアログを閉じる

レビュー表

- [x] エラーの内容によって、メッセージを分けているか
- [ ] freezed_annotation, freezed のコミットを一緒にまとめているか
- [x] クリックイベントをメソッドとして切り出しているか
- [x] Dialog をコンポーネントとして抽出しているか
- [ ] エラーハンドリングが[公式ドキュメント](https://dart.dev/effective-dart/usage#error-handling)に従っているか

## 動作

- expect

https://github.com/yumemi-inc/flutter-training-template/blob/main/docs/sessions/images/error/demo.gif?raw=true

- iOS

https://github.com/oyuno-hito/flutter-training/assets/41560259/4f4b998c-0d0a-4fc5-b269-06eee0effd1f

- android

https://github.com/oyuno-hito/flutter-training/assets/41560259/a6ef4aef-d3d0-40d9-9a37-d0a9f31d6f4d

